### PR TITLE
Replace usage of deprecated BlobBuilder

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -932,9 +932,7 @@ function saveProfileToLocalStorage() {
 }
 function downloadProfile() {
   Parser.getSerializedProfile(true, function (serializedProfile) {
-    var bb = new MozBlobBuilder();
-    bb.append(serializedProfile);
-    var blob = bb.getBlob("application/octet-stream");
+    var blob = new Blob([serializedProfile], { "type": "application/octet-stream" });
     location.href = window.URL.createObjectURL(blob);
   });
 }


### PR DESCRIPTION
BlobBuilder has been removed on m-c in https://bugzilla.mozilla.org/show_bug.cgi?id=744907

Zip.js has already been updated upstream but needs to be pulled-in. It should probably use a git submodule.
