### PR TITLE
sampleBar UI tweaks

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -152,6 +152,12 @@ body {
   right: 0;
   height: 100%;
 }
+#sampleBar a {
+  text-decoration: none;
+}
+#sampleBar a:hover {
+  text-decoration: underline;
+}
 #fileList {
   position: absolute;
   top: 0;

--- a/js/ui.js
+++ b/js/ui.js
@@ -296,7 +296,7 @@ function SampleBar() {
   this._header.alt = "This shows the heaviest leaf of the selected sample. Use this to get a quick glimpse of where the selection is spending most of its time.";
   this._container.appendChild(this._header);
 
-  this._text = document.createElement("span");
+  this._text = document.createElement("ul");
   this._text.style.whiteSpace = "pre";
   this._text.innerHTML = "Sample text";
   this._container.appendChild(this._text);
@@ -316,11 +316,12 @@ SampleBar.prototype = {
       var functionObj = gMergeFunctions ? gFunctions[sample[i]] : gFunctions[symbols[sample[i]].functionIndex];
       if (!functionObj)
         continue;
+      var functionItem = document.createElement("li");
       var functionLink = document.createElement("a");
-      functionLink.textContent = "- " + functionObj.functionName;
+      functionLink.textContent = functionLink.title = functionObj.functionName;
       functionLink.href = "#";
-      this._text.appendChild(functionLink);
-      this._text.appendChild(document.createElement("br"));
+      functionItem.appendChild(functionLink);
+      this._text.appendChild(functionItem);
       list.push(functionObj.functionName);
       functionLink.selectIndex = i;
       functionLink.onclick = function() {


### PR DESCRIPTION
- Use ul instead of a span with br for nicer bullets
- add @title so long functions can be seen on hover rather than scrolling
- remove text-decoration to make underscores easier to read
