### PR TITLE
Remove -webkit- and (some) -moz- CSS properties

### DIFF
--- a/light/css/tree.css
+++ b/light/css/tree.css
@@ -1,6 +1,5 @@
 .treeViewContainer {
   -moz-user-select: none;
-  -webkit-user-select: none;
   user-select: none;
   cursor: default;
   line-height: 16px;
@@ -22,8 +21,6 @@
 .treeColumnHeader {
   position: absolute;
   display: block;
-  background: -moz-linear-gradient(#FFF 45%, #EEE 60%);
-  background: -webkit-linear-gradient(#FFF 45%, #EEE 60%);
   background: linear-gradient(#FFF 45%, #EEE 60%);
   margin: 0;
   padding: 0;
@@ -89,17 +86,11 @@
 
 .treeViewVerticalScrollbox,
 .treeViewHorizontalScrollbox {
-  background: -moz-linear-gradient(white, white 50%, #F0F5FF 50%, #F0F5FF);
-  background: -webkit-linear-gradient(white, white 50%, #F0F5FF 50%, #F0F5FF);
   background: linear-gradient(white, white 50%, #F0F5FF 50%, #F0F5FF);
   background-size: 100px 32px;
 }
 
 .leftColumnBackground {
-  background: -moz-linear-gradient(left, transparent, transparent 98px, #CCC 98px, #CCC 99px, transparent 99px),
-    -moz-linear-gradient(white, white 50%, #F0F5FF 50%, #F0F5FF);
-  background: -webkit-linear-gradient(left, transparent, transparent 98px, #CCC 98px, #CCC 99px, transparent 99px),
-    -webkit-linear-gradient(white, white 50%, #F0F5FF 50%, #F0F5FF);
   background: linear-gradient(left, transparent, transparent 98px, #CCC 98px, #CCC 99px, transparent 99px),
     linear-gradient(white, white 50%, #F0F5FF 50%, #F0F5FF);
   background-size: auto, 100px 32px;

--- a/light/css/ui.css
+++ b/light/css/ui.css
@@ -28,10 +28,6 @@ body {
   padding: 20px;
   background-color: rgb(229,229,229);
   background-image: url(../images/noise.png),
-                    -moz-linear-gradient(rgba(255,255,255,.5),rgba(255,255,255,.2));
-  background-image: url(../images/noise.png),
-                    -webkit-linear-gradient(rgba(255,255,255,.5),rgba(255,255,255,.2));
-  background-image: url(../images/noise.png),
                     linear-gradient(rgba(255,255,255,.5),rgba(255,255,255,.2));
   text-shadow: rgba(255, 255, 255, 0.4) 0 1px;
 }
@@ -58,15 +54,13 @@ body {
   height: 16px;
 }
 .finishedProfilePaneBackgroundCover {
-  -webkit-animation: darken 300ms cubic-bezier(0, 0, 1, 0);
-  -moz-animation: darken 300ms cubic-bezier(0, 0, 1, 0);
+  animation: darken 300ms cubic-bezier(0, 0, 1, 0);
   background-color: rgba(0, 0, 0, 0.5);
 }
 .finishedProfilePane {
-  -webkit-animation: appear 300ms ease-out;
-  -moz-animation: appear 300ms ease-out;
+  animation: appear 300ms ease-out;
 }
-@-webkit-keyframes darken {
+@keyframes darken {
   from {
     opacity: 0;
   }
@@ -74,34 +68,14 @@ body {
     opacity: 1;
   }
 }
-@-webkit-keyframes appear {
+@keyframes appear {
   from {
-    -webkit-transform: scale(0.3);
+    transform: scale(0.3);
     opacity: 0;
     pointer-events: none;
   }
   to {
-    -webkit-transform: scale(1);
-    opacity: 1;
-    pointer-events: auto;
-  }
-}
-@-moz-keyframes darken {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-@-moz-keyframes appear {
-  from {
-    -moz-transform: scale(0.3);
-    opacity: 0;
-    pointer-events: none;
-  }
-  to {
-    -moz-transform: scale(1);
+    transform: scale(1);
     opacity: 1;
     pointer-events: auto;
   }
@@ -111,8 +85,6 @@ body {
   right: 0;
   height: 29px;
   left: 0;
-  background: -moz-linear-gradient(#FFF 50%, #F3F3F3 55%);
-  background: -webkit-linear-gradient(#FFF 50%, #F3F3F3 55%);
   background: linear-gradient(#FFF 50%, #F3F3F3 55%);
   border-bottom: 1px solid #CCC;
   margin: 0;
@@ -120,8 +92,6 @@ body {
   overflow: hidden;
 }
 .breadcrumbTrailItem {
-  background: -moz-linear-gradient(#FFF 50%, #F3F3F3 55%);
-  background: -webkit-linear-gradient(#FFF 50%, #F3F3F3 55%);
   background: linear-gradient(#FFF 50%, #F3F3F3 55%);
   display: block;
   margin: 0;
@@ -131,7 +101,6 @@ body {
   padding: 0 10px;
   font-size: 12px;
   -moz-user-select: none;
-  -webkit-user-select: none;
   user-select: none;
   cursor: default;
   border-right: 1px solid #CCC;
@@ -141,17 +110,7 @@ body {
   white-space: nowrap;
   position: relative;
 }
-@-webkit-keyframes slide-out {
-  from {
-    margin-left: -270px;
-    opacity: 0;
-  }
-  to {
-    margin-left: 0;
-    opacity: 1;
-  }
-}
-@-moz-keyframes slide-out {
+@keyframes slide-out {
   from {
     margin-left: -270px;
     opacity: 0;
@@ -162,12 +121,9 @@ body {
   }
 }
 .breadcrumbTrailItem:not(:first-child) {
-  -moz-animation: slide-out;
-  -moz-animation-duration: 400ms;
-  -moz-animation-timing-function: ease-out;
-  -webkit-animation: slide-out;
-  -webkit-animation-duration: 400ms;
-  -webkit-animation-timing-function: ease-out;
+  animation: slide-out;
+  animation-duration: 400ms;
+  animation-timing-function: ease-out;
 }
 .breadcrumbTrailItem.selected {
   background: linear-gradient(#E5E5E5 50%, #DADADA 55%);
@@ -176,10 +132,8 @@ body {
   background: linear-gradient(#F2F2F2 50%, #E6E6E6 55%);
 }
 .breadcrumbTrailItem.deleted {
-  -moz-transition: 400ms ease-out;
-  -moz-transition-property: opacity, margin-left;
-  -webkit-transition: 400ms ease-out;
-  -webkit-transition-property: opacity, margin-left;
+  transition: 400ms ease-out;
+  transition-property: opacity, margin-left;
   opacity: 0;
   margin-left: -270px;
 }
@@ -234,7 +188,6 @@ body {
 }
 .sideBar {
   -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
   position: absolute;
   left: 0;
@@ -281,8 +234,6 @@ body {
   right: 0;
   left: 0;
   border-bottom: 1px solid #CCC;
-  background: -moz-linear-gradient(#EEE, #CCC);
-  background: -webkit-linear-gradient(#EEE, #CCC);
   background: linear-gradient(#EEE, #CCC);
 }
 .histogramHilite {
@@ -322,8 +273,6 @@ body {
   text-indent: 8px;
 }
 .fileListItem.selected {
-  background: -moz-linear-gradient(#4B91D7 1px, #5FA9E4 1px, #5FA9E4 2px, #58A0DE 3px, #2B70C7 39px, #2763B4 39px);
-  background: -webkit-linear-gradient(#4B91D7 1px, #5FA9E4 1px, #5FA9E4 2px, #58A0DE 3px, #2B70C7 39px, #2763B4 39px);
   background: linear-gradient(#4B91D7 1px, #5FA9E4 1px, #5FA9E4 2px, #58A0DE 3px, #2B70C7 39px, #2763B4 39px);
   color: #FFF;
   text-shadow: 0 1px rgba(0, 0, 0, 0.3);
@@ -348,10 +297,8 @@ body {
   opacity: 0;
   pointer-events: none;
   background: rgba(120, 120, 120, 0.2);
-  -moz-transition: 200ms ease-in-out;
-  -moz-transition-property: visibility, opacity;
-  -webkit-transition: 200ms ease-in-out;
-  -webkit-transition-property: visibility, opacity;
+  transition: 200ms ease-in-out;
+  transition-property: visibility, opacity;
 }
 .busyCover.busy {
   visibility: visible;
@@ -365,7 +312,6 @@ body {
   margin: -12px;
 }
 label {
-  -webkit-user-select: none;
   -moz-user-select: none;
 }
 .videoPane {


### PR DESCRIPTION
This patch was taken a patch to [bug 822110](https://bugzilla.mozilla.org/show_bug.cgi?id=822110). It removes all -webkit- and some -moz- CSS properties.
