### PR TITLE
Remove fixed height from .fileListItem

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -344,7 +344,6 @@ body {
   display: block;
   margin: 0;
   padding: 0;
-  height: 40px;
   text-indent: 8px;
   cursor: pointer;
 }


### PR DESCRIPTION
This lets fileListItem entries be auto-height, which fixes #30 (float effects bleeding out of one fileListItem and into the next).

Screencast of what this looks like, locally:
   http://people.mozilla.org/~dholbert/bugreports/cleopatra.ogv

The screencast first the current rendering, with the 40px-tall areas (higlighted as I select different entries in devtools) clearly not at all matching up with the actual positioning of the entries, due to a float bleeding out of each item and impacting the row below it [and then being relatively positioned away].

Then the screencast shows the 40px height being removed, and the entries being auto-sized, which prevents them from overlapping.
